### PR TITLE
Update potplayer.reg

### DIFF
--- a/potplayer.reg
+++ b/potplayer.reg
@@ -5,4 +5,4 @@ Windows Registry Editor Version 5.00
 [HKEY_CLASSES_ROOT\potplayer\shell]
 [HKEY_CLASSES_ROOT\potplayer\shell\open]
 [HKEY_CLASSES_ROOT\potplayer\shell\open\command]
-@="powershell -File C:\\codes\\Jellyfin-Potplay\\potplayer.ps1 %1"
+@="powershell -File C:\\codes\\Jellyfin-Potplayer\\potplayer.ps1 %1"


### PR DESCRIPTION
Change 'Jellyfin-Potplay' to 'Jellyfin-Potplayer' in the path for the project name is 'Jellyfin-Potplayer'. If someone only changes the prefix before 'Jellyfin-Potplay', he will probably get error durring execution.